### PR TITLE
ci: Add workflow_dispatch option to force build

### DIFF
--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -4,6 +4,13 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
+    inputs:
+      force_build:
+        description: 'Force build even if no new version is available'
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   release:
@@ -46,7 +53,7 @@ jobs:
   container_build:
     runs-on: ubuntu-latest
     needs: release
-    if: needs.release.outputs.published == 'True'
+    if: needs.release.outputs.published == 'True' || github.event.inputs.force_build == 'true'
     permissions:
       packages: write
 


### PR DESCRIPTION
Because no new version was released since we introduced the CI for docker builds